### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/pardef.el
+++ b/pardef.el
@@ -50,6 +50,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'subr-x)
 (require 'dash)
 
 (defgroup pardef nil


### PR DESCRIPTION
```
pardef.el:1020:1:Warning: the following functions are not known to be defined: string-join,
    string-empty-p, string-blank-p, string-trim-left
```